### PR TITLE
fix(ci): Github Actions 워크플로우 os 환경 수정 (ubuntu-24.04 적용) (#8)

### DIFF
--- a/backend/.github/workflows/test.yml
+++ b/backend/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: test
 on: pull_request
 jobs:
     test:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3


### PR DESCRIPTION
- runs-on을 ubuntu-22.04 -> unbuntu-24.04로 변경
- 워크플로우 정상 작동을 위한 환경 수정